### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,10 +1,8 @@
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.9'
+- '3.10'

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,4 +24,5 @@ bld.bat text eol=crlf
 /README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true
 build-locally.py linguist-generated=true
+pixi.toml linguist-generated=true
 shippable.yml linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,19 +31,17 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-curl -fsSL https://pixi.sh/install.sh | bash
-export PATH="~/.pixi/bin:$PATH"
 pushd "${FEEDSTOCK_ROOT}"
 arch=$(uname -m)
 if [[ "$arch" == "x86_64" ]]; then
   arch="64"
 fi
-sed -i.bak "s/platforms = .*/platforms = [\"linux-${arch}\"]/" pixi.toml
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
 echo "Creating environment"
-PIXI_CACHE_DIR=/opt/conda pixi install
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
 pixi list
 echo "Activating environment"
-eval "$(pixi shell-hook)"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
 mv pixi.toml.bak pixi.toml
 popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -130,7 +130,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/ml-collections-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -26,6 +27,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"
@@ -37,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -53,38 +70,43 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
     p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
+    p.add_argument(
         "--debug",
         action="store_true",
         help="Setup debug environment using `conda debug`",
     )
-    p.add_argument(
-        "--output-id", help="If running debug, specify the output to setup."
-    )
+    p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 
     ns = p.parse_args(args=args)
     verify_config(ns)
@@ -97,10 +119,10 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
-        recipe_license_file = os.path.join(
-            "recipe", "recipe-scripts-license.txt"
-        )
+        recipe_license_file = os.path.join("recipe", "recipe-scripts-license.txt")
         if os.path.exists(recipe_license_file):
             os.remove(recipe_license_file)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,34 +1,52 @@
+# -*- mode: toml -*-
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: toml -*-
+"$schema" = "https://pixi.sh/v0.59.0/schema/manifest/schema.json"
 
-[project]
+[workspace]
 name = "ml-collections-feedstock"
-version = "3.44.3"
+version = "3.54.2"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/ml-collections-feedstock"
 authors = ["@conda-forge/ml-collections"]
 channels = ["conda-forge"]
-platforms = ['linux-64', 'osx-64', 'win-64']
+platforms = ["linux-64", "osx-64", "win-64"]
+requires-pixi = ">=0.59.0"
 
 [dependencies]
 conda-build = ">=24.1"
 conda-forge-ci-setup = "4.*"
 rattler-build = "*"
 
-[tasks]
-inspect-all = "inspect_artifacts --all-packages"
-build = "rattler-build build --recipe recipe"
-"build-linux_64_" = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
-"inspect-linux_64_" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build ml-collections-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build ml-collections-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of ml-collections-feedstock packages built for variant linux_64_"
 
 [feature.smithy.dependencies]
 conda-smithy = "*"
-
-[feature.smithy.tasks]
-build-locally = "python ./build-locally.py"
-smithy = "conda-smithy"
-rerender = "conda-smithy rerender"
-lint = "conda-smithy lint recipe"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
 
 [environments]
 smithy = ["smithy"]
+
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -18,7 +18,7 @@ build:
 
 requirements:
   host:
-    - python ${{ python_min }}
+    - python ${{ python_min }}.*
     - pip
     - flit-core
   run:


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{ python_min }}` to make them valid match specs.

This is a build-fix only — the existing package on conda-forge is unaffected, so no new build needs to be pushed. That's why the build number isn't bumped.